### PR TITLE
Improved the way the network plays

### DIFF
--- a/play.py
+++ b/play.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python
 
 from BaseHTTPServer import BaseHTTPRequestHandler, HTTPServer
-from utils import take_screenshot, prepare_image
+from utils import take_screenshot, prepare_image, convert_to_probability
 from utils import XboxController
 import tensorflow as tf
 import model
 from termcolor import cprint
+import numpy as np
 
 PORT_NUMBER = 8082
 
@@ -33,6 +34,21 @@ class myHandler(BaseHTTPRequestHandler):
         ## Think
         joystick = model.y.eval(feed_dict={model.x: [vec], model.keep_prob: 1.0})[0]
 
+        ### Pre-process the controls
+        #### There is a bias to drive straight so multiply x axis by a multiplier
+        x_mult = 2
+        joystick[0] = max(min(joystick[0] * x_mult, 1), -1)
+
+        #### Convert button pushes to 'probabilities' then sample 0/1
+        p2 = convert_to_probability(joystick[2])
+        joystick[2] = np.random.choice(a = [0,1], p = [1-p2, p2])
+
+        p3 = convert_to_probability(joystick[3])
+        joystick[3] = np.random.choice(a = [0,1], p = [1-p3, p3])
+
+        p4 = convert_to_probability(joystick[4])
+        joystick[4] = np.random.choice(a = [0,1], p = [1-p4, p4])
+
         ## Act
         ### manual override
         manual_override = real_controller.manual_override()
@@ -45,16 +61,16 @@ class myHandler(BaseHTTPRequestHandler):
         output = [
             int(joystick[0] * 80),
             int(joystick[1] * 80),
-            int(round(joystick[2])),
-            int(round(joystick[3])),
-            int(round(joystick[4])),
+            int(joystick[2]),
+            int(joystick[3]),
+            int(joystick[4])
         ]
 
         ### print to console
         if (manual_override):
             cprint("Manual: " + str(output), 'yellow')
         else:
-            cprint("AI: " + str(output), 'green')
+            cprint("AI: " + str(output) + str(p2), 'green')
 
         ### respond with action
         self.send_response(200)

--- a/utils.py
+++ b/utils.py
@@ -20,6 +20,11 @@ IMG_W = 200
 IMG_H = 66
 
 
+def convert_to_probability(val):
+    p = max(min(val, 1), 0)
+    return(p)
+
+
 def take_screenshot():
     screen = wx.ScreenDC()
     size = screen.GetSize()


### PR DESCRIPTION
The below is copied from my previous PR:

I noticed the AI did not like turning strong enough although the direction of the turn was often correct. For that reason I decided to multiply the x-axis values by 2 (arbitrary, this can be tuned), which greatly improved driving performance (interestingly, this was also reported by Nvidia[1]). Another thing is that the button presses were being determined by rounding a value (roughly...) between 0-1, I thought it would be better to make this stochastic so that the value represented the probability of pushing the button when viewing a given scene. I didn't set a pRNG seed, so each race will be different (at least slightly).

[1] "To remove a bias towards driving straight the training data includes a higher proportion of frames that represent road curves."
https://arxiv.org/pdf/1604.07316.pdf