### PR TITLE
Modified button pushes to be probabilities

### DIFF
--- a/play.py
+++ b/play.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python
 
 from BaseHTTPServer import BaseHTTPRequestHandler, HTTPServer
-from utils import take_screenshot, prepare_image
+from utils import take_screenshot, prepare_image, convert_to_probability
 from utils import XboxController
 import tensorflow as tf
 import model
 from termcolor import cprint
+import numpy as np
 
 PORT_NUMBER = 8082
 
@@ -33,6 +34,19 @@ class myHandler(BaseHTTPRequestHandler):
         ## Think
         joystick = model.y.eval(feed_dict={model.x: [vec], model.keep_prob: 1.0})[0]
 
+        ### Pre-process the controls
+        joystick[0] = max(min(joystick[0], 1), -1)
+
+        #### Convert button pushes to 'probabilities' then sample 0/1
+        p2 = convert_to_probability(joystick[2])
+        joystick[2] = np.random.choice(a = [0,1], p = [1-p2, p2])
+
+        p3 = convert_to_probability(joystick[3])
+        joystick[3] = np.random.choice(a = [0,1], p = [1-p3, p3])
+
+        p4 = convert_to_probability(joystick[4])
+        joystick[4] = np.random.choice(a = [0,1], p = [1-p4, p4])
+
         ## Act
         ### manual override
         manual_override = real_controller.manual_override()
@@ -45,9 +59,9 @@ class myHandler(BaseHTTPRequestHandler):
         output = [
             int(joystick[0] * 80),
             int(joystick[1] * 80),
-            int(round(joystick[2])),
-            int(round(joystick[3])),
-            int(round(joystick[4])),
+            int(joystick[2]),
+            int(joystick[3]),
+            int(joystick[4])
         ]
 
         ### print to console

--- a/utils.py
+++ b/utils.py
@@ -20,6 +20,11 @@ IMG_W = 200
 IMG_H = 66
 
 
+def convert_to_probability(val):
+    p = max(min(val, 1), 0)
+    return(p)
+
+
 def take_screenshot():
     screen = wx.ScreenDC()
     size = screen.GetSize()


### PR DESCRIPTION
Currently the network returns a value approximately between 0-1 and this is rounded to either push the button (1) or not (0). Instead, I tried truncating the value to between 0-1 and interpreting this as a probability. The probability is used by np.random.choice to pseudorandomly choose whether to press the buttons during each update, the resulting 0/1 is then sent as the controller instruction.