### PR TITLE
Run HTTPServer on background thread to allow graceful exit

### DIFF
--- a/play.py
+++ b/play.py
@@ -5,6 +5,7 @@ from utils import take_screenshot, prepare_image
 from utils import XboxController
 import tensorflow as tf
 import model
+import threading
 from termcolor import cprint
 
 PORT_NUMBER = 8082
@@ -72,4 +73,8 @@ class myHandler(BaseHTTPRequestHandler):
 if __name__ == '__main__':
     server = HTTPServer(('', PORT_NUMBER), myHandler)
     print 'Started httpserver on port ' , PORT_NUMBER
-    server.serve_forever()
+    thread = threading.Thread(target=server.serve_forever, args=())
+    thread.daemon = True
+    thread.start()
+    raw_input('Serving now... press <Enter> to shut down.')
+    print 'Shutting down...'


### PR DESCRIPTION
Simple fix to allow `ENTER` to be used to stop `play.py` by running the `HTTPServer` on a background thread and waiting on input. Fixes issue #23 

Note: killing the `HTTPServer` causes a segfault in the custom input driver for mupen64plus. This was already true if you killed the `play.py` script in any other way, so this doesn't seem like a deal-breaker.
