### PR TITLE
Changed prepare samples to use Numpy array for X data

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -207,10 +207,10 @@ def prepare(samples):
     
     for sample in samples:
         image_files = load_imgs(sample)
-        numpics += len(image_files)
+        num_samples += len(image_files)
         
-    X = np.empty(shape=(numpics,Sample.IMG_H,Sample.IMG_W,3),dtype=np.uint8)
-    print(f"There are {numpics} samples")
+    X = np.empty(shape=(num_samples,Sample.IMG_H,Sample.IMG_W,3),dtype=np.uint8)
+    print(f"There are {num_samples} samples")
     
     idx = 0
 for idx, sample in enumerate(samples):
@@ -227,7 +227,7 @@ for idx, sample in enumerate(samples):
             image = imread(image_file)
             vec = resize_image(image)
             X[idx] = vec
-            idx += 1
+            
 
     print("Saving to file...")
     y = np.concatenate(y)

--- a/utils.py
+++ b/utils.py
@@ -213,7 +213,7 @@ def prepare(samples):
     print(f"There are {numpics} samples")
     
     idx = 0
-    for sample in samples:
+for idx, sample in enumerate(samples):
         print(sample)
 
         # load sample


### PR DESCRIPTION
The previous method, with a list, took a lot of memory. With the old method, using 20 GB worth of 1080p images, memory usage would exceed 16 GB resulting in errors when I tried to save the data. With the updated code it does not exceed 1 GB (with the same data). Kind of solves this issue: https://github.com/kevinhughes27/TensorKart/issues/2